### PR TITLE
修复前缀转义

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,7 +67,8 @@ Context.service('worker')
 export const name = 'eval'
 
 export function apply(ctx: Context, config: Config = {}) {
-  const { prefix, authority } = config = { ...defaultConfig, ...config }
+  const { authority } = config = { ...defaultConfig, ...config }
+  const prefix = segment.escape(config.prefix)
 
   ctx.worker = new EvalWorker(ctx, config)
 


### PR DESCRIPTION
默认的快捷调用前缀是`>`，但好像需要转义后才能识别